### PR TITLE
Correct haddock markup for bold text

### DIFF
--- a/src/Data/Discrimination/Grouping.hs
+++ b/src/Data/Discrimination/Grouping.hs
@@ -216,7 +216,7 @@ runGroup (Group m) xs = runLazy (\p0 -> do
 --
 -- This combinator still operates in linear time, at the expense of storing history.
 --
--- The result equivalence classes are _not_ sorted, but the grouping is stable.
+-- The result equivalence classes are __not__ sorted, but the grouping is stable.
 --
 -- @
 -- 'group' = 'groupWith' 'id'
@@ -226,7 +226,7 @@ group as = runGroup grouping [(a, a) | a <- as]
 
 -- | /O(n)/. This is a replacement for 'GHC.Exts.groupWith' using discrimination.
 --
--- The result equivalence classes are _not_ sorted, but the grouping is stable.
+-- The result equivalence classes are __not__ sorted, but the grouping is stable.
 groupWith :: Grouping b => (a -> b) -> [a] -> [[a]]
 groupWith f as = runGroup grouping [(f a, a) | a <- as]
 


### PR DESCRIPTION
Just a minor correction to use `__not__` for bold text instead of `_not_` in `Data.Discrimination.Grouping` haddock of `group` and `groupWith` ;)