### PR TITLE
Fix 'conquer' returning [[]] and sorts inspecting more of the input than necessary.

### DIFF
--- a/src/Data/Discrimination/Sorting.hs
+++ b/src/Data/Discrimination/Sorting.hs
@@ -77,7 +77,7 @@ instance Contravariant Sort where
   contramap f (Sort g) = Sort $ g . fmap (first f)
 
 instance Divisible Sort where
-  conquer = Sort $ return . fmap snd
+  conquer = Sort $ \x -> take 1 x >> [fmap snd x]
   divide k (Sort l) (Sort r) = Sort $ \xs ->
     l [ (b, (c, d)) | (a,d) <- xs, let (b, c) = k a] >>= r
 


### PR DESCRIPTION
Fixes #3.

Note this new behavior matches the original formulation in http://www.diku.dk/hjemmesider/ansatte/henglein/papers/henglein2011a.pdf, since 'sdisc' has the clause "sdisc _ [] = []" before "sdisc TrivO xs = [[ v | (_, v) <- xs ]]".
