### PR TITLE
Bump lower bound on base since discrimination doesn't build on GHC 7.8.

### DIFF
--- a/discrimination.cabal
+++ b/discrimination.cabal
@@ -44,7 +44,7 @@ library
 
   build-depends:
     array         >= 0.5    && < 0.6,
-    base          >= 4.7    && < 5,
+    base          >= 4.8    && < 5,
     containers    >= 0.4    && < 0.6,
     contravariant >= 1.3.1  && < 2,
     deepseq       >= 1.3    && < 1.5,


### PR DESCRIPTION
If you accept this, please publish a new revision to hackage. Sorry I didn't catch this last time I got you to publish a revision.