### PR TITLE
Don't benchmark on GHC 7.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_cache:
 matrix:
   include:
     - compiler: "ghc-7.10.3"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      env: BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.10.3], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks


### PR DESCRIPTION
Benchmarks have a constraint base >= 4.9, so don't try to run the benchmarkson Travis.