### PR TITLE
Update hyperlinks to Fritz Henglein's articles

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@ discrimination
 [![Hackage](https://img.shields.io/hackage/v/discrimination.svg)](https://hackage.haskell.org/package/discrimination) [![Build Status](https://secure.travis-ci.org/ekmett/discrimination.png?branch=master)](http://travis-ci.org/ekmett/discrimination)
 
 This package provides linear time sorting, partitioning, and joins for a wide array of Haskell data types. This work is based on a
-"final encoding" of the ideas presented in [multiple](http://www.diku.dk/hjemmesider/ansatte/henglein/papers/henglein2011a.pdf) [papers](http://www.diku.dk/hjemmesider/ansatte/henglein/papers/henglein2011c.pdf) and [talks](https://www.youtube.com/watch?v=sz9ZlZIRDAg) by [Fritz Henglein](http://www.diku.dk/hjemmesider/ansatte/henglein/).
+"final encoding" of the ideas presented in [multiple](http://hjemmesider.diku.dk/~henglein/papers/henglein2011a.pdf) [papers](http://hjemmesider.diku.dk/~henglein/papers/henglein2011c.pdf) and [talks](https://www.youtube.com/watch?v=sz9ZlZIRDAg) by [Fritz Henglein](http://hjemmesider.diku.dk/~henglein).
 
 By adopting a final encoding we can enjoy many instances for standard classes, lawfully, without quotienting.
 


### PR DESCRIPTION
The Department of Computer Science at the University of Copenhagen decided to change their website, so now old links are broken.

Notice that the [current list of publications](http://hjemmesider.diku.dk/~henglein/bib/author/Fritz.Henglein.html) is still broken; I've notified Fritz.