### PR TITLE
Bump lower bound for primitive

### DIFF
--- a/discrimination.cabal
+++ b/discrimination.cabal
@@ -51,7 +51,7 @@ library
     ghc-prim,
     hashable      >= 1.2    && < 1.3,
     integer-gmp,
-    primitive     >= 0.6    && < 0.7,
+    primitive     >= 0.6.4  && < 0.7,
     profunctors   >= 5      && < 6,
     promises      >= 0.2    && < 0.4,
     semigroups    >= 0.16.2 && < 1,


### PR DESCRIPTION
`PrimArray` requires `primitive >= 0.6.4`.