### PR TITLE
Grouping and Sorting instances for Data.Ord.Down

### DIFF
--- a/discrimination.cabal
+++ b/discrimination.cabal
@@ -47,7 +47,7 @@ library
     containers    >= 0.5.6.2 && < 0.7,
     contravariant >= 1.5.3   && < 2,
     deepseq       >= 1.4.1.1 && < 1.5,
-    ghc-prim,
+    ghc-prim      >= 0.3.1.0 && < 1,
     hashable      >= 1.2.7.0 && < 1.5,
     primitive     >= 0.7.1.0 && < 0.8,
     promises      >= 0.3     && < 0.4,

--- a/src/Data/Discrimination/Grouping.hs
+++ b/src/Data/Discrimination/Grouping.hs
@@ -38,6 +38,7 @@ import Data.Hashable
 import Data.Int
 import Data.List.NonEmpty (NonEmpty)
 import Data.Semigroup hiding (Any)
+import Data.Ord
 import Data.Primitive.MutVar
 import Data.Promise
 import Data.Proxy
@@ -157,6 +158,7 @@ instance Grouping Int where grouping = contramap fromIntegral groupingWord64
 instance Grouping Char where grouping = contramap (fromIntegral . fromEnum) groupingWord64
 
 instance Grouping Bool
+instance Grouping a => Grouping (Down a)
 instance Grouping Ordering
 instance (Grouping a, Grouping b) => Grouping (a, b)
 instance (Grouping a, Grouping b, Grouping c) => Grouping (a, b, c)

--- a/src/Data/Discrimination/Sorting.hs
+++ b/src/Data/Discrimination/Sorting.hs
@@ -47,12 +47,14 @@ import Data.IntSet as IntSet
 import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map as Map
+import Data.Ord
 import Data.Proxy
 import Data.Semigroup hiding (Any)
 import Data.Set as Set
 import Data.Typeable
 import Data.Void
 import Data.Word
+import GHC.Prim
 import Numeric.Natural (Natural)
 import Prelude hiding (read, concat)
 
@@ -178,6 +180,10 @@ instance Sorting Char where
 
 instance Sorting Void
 instance Sorting Bool
+
+instance forall a. Sorting a => Sorting (Down a) where
+  sorting = Sort $ \(xs :: [(Down a, b)]) -> reverse $ runSort sorting (coerce xs :: [(a, b)])
+
 instance Sorting Ordering
 instance Sorting a => Sorting [a]
 instance Sorting a => Sorting (NonEmpty a)


### PR DESCRIPTION
A sorting instance of `Down` enables the user to write `sortWith Down` to sort in reverse order.