### PR TITLE
GHC 9.6 and primitive-0.8 support

### DIFF
--- a/discrimination.cabal
+++ b/discrimination.cabal
@@ -49,7 +49,7 @@ library
     deepseq       >= 1.4.1.1 && < 1.5,
     ghc-prim,
     hashable      >= 1.2.7.0 && < 1.5,
-    primitive     >= 0.7.1.0 && < 0.8,
+    primitive     >= 0.7.1.0 && < 0.9,
     promises      >= 0.3     && < 0.4,
     transformers  >= 0.4.2.0 && < 0.7
 


### PR DESCRIPTION
- Allow primitive-0.8
- ~~Don't need import on base-4.18~~
