### PR TITLE
Allow hashable-1.5 and containers-0.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.2
             compilerKind: ghc
             compilerVersion: 9.10.2

--- a/discrimination.cabal
+++ b/discrimination.cabal
@@ -45,11 +45,11 @@ library
   build-depends:
     array         >= 0.5.1.0 && < 0.6,
     base          >= 4.9     && < 5,
-    containers    >= 0.5.6.2 && < 0.8,
+    containers    >= 0.5.6.2 && < 0.9,
     contravariant >= 1.5.3   && < 2,
     deepseq       >= 1.4.1.1 && < 1.6,
     ghc-prim,
-    hashable      >= 1.2.7.0 && < 1.5,
+    hashable      >= 1.2.7.0 && < 1.6,
     primitive     >= 0.7.1.0 && < 0.10,
     promises      >= 0.3     && < 0.4,
     transformers  >= 0.4.2.0 && < 0.7

--- a/discrimination.cabal
+++ b/discrimination.cabal
@@ -12,7 +12,7 @@ homepage:      http://github.com/ekmett/discrimination/
 bug-reports:   http://github.com/ekmett/discrimination/issues
 copyright:     Copyright (C) 2014-2015 Edward A. Kmett
 build-type:    Simple
-tested-with:   GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.8, GHC == 9.4.8, GHC == 9.6.7, GHC==9.8.4, GHC==9.10.2
+tested-with:   GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.8, GHC == 9.4.8, GHC == 9.6.7, GHC==9.8.4, GHC==9.10.2, GHC==9.12.2
 synopsis:      Fast generic linear-time sorting, joins and container construction.
 description:
   This package provides fast, generic, linear-time discrimination and sorting.


### PR DESCRIPTION
Tested with
```
cabal test -w ghc-9.12 -c 'containers>=0.8' --allow-newer='hashable:containers,parallel:containers,aeson:containers,witherable:containers,semialign:containers,scientific:containers,indexed-traversable:containers,microstache:containers,quickcheck-instances:containers' --enable-tests
```

A revision would be much appreciated.